### PR TITLE
feat(metadata): add vulnerability-database-updated-at in metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Configuration of the adapter is done via environment variables at startup.
 | `SCANNER_API_SERVER_WRITE_TIMEOUT` | `15s` | The maximum duration before timing out writes of the response. |
 | `SCANNER_API_SERVER_IDLE_TIMEOUT`  | `60s` | The maximum amount of time to wait for the next request when keep-alives are enabled. |
 | `SCANNER_CLAIR_URL`                | `http://harbor-harbor-clair:6060` | Clair URL |
+| `SCANNER_CLAIR_DATABASE_URL`       | | The Clair database URL, it is used to fetch vulnerability database updated time of the Clair. Its format is `postgresql://user:password@host/db?sslmode=disable` |
 | `SCANNER_STORE_REDIS_URL`       | `redis://harbor-harbor-redis:6379` | Redis server URI for a redis store. |
 | `SCANNER_STORE_REDIS_NAMESPACE` | `harbor.scanner.clair:store` | A namespace for keys in a redis store. |
 | `SCANNER_STORE_REDIS_POOL_MAX_ACTIVE` | `5`  | The max number of connections allocated by the pool for a redis store. |

--- a/go.mod
+++ b/go.mod
@@ -9,9 +9,11 @@ require (
 	github.com/gomodule/redigo v2.0.0+incompatible
 	github.com/google/uuid v1.1.1
 	github.com/gorilla/mux v1.7.2
+	github.com/lib/pq v1.2.0
 	github.com/prometheus/client_golang v1.2.1
 	github.com/sirupsen/logrus v1.4.2
 	github.com/stretchr/testify v1.3.0
 	github.com/testcontainers/testcontainers-go v0.0.8
+	github.com/xo/dburl v0.0.0-20191005012637-293c3298d6c0
 	golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898
 )

--- a/go.sum
+++ b/go.sum
@@ -80,6 +80,8 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/lib/pq v1.2.0 h1:LXpIM/LZ5xGFhOpXAQUIMM1HdyqzVYM13zNdjCEEcA0=
+github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -135,6 +137,8 @@ github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/testcontainers/testcontainers-go v0.0.8 h1:71E+jJpE9dSgydCfn5aWESVM7+l8giw/DBWaTy35TTU=
 github.com/testcontainers/testcontainers-go v0.0.8/go.mod h1:/f0q4FvAHzjirds5ddhxA7sM04QQMynxO3WQUU/yYHI=
+github.com/xo/dburl v0.0.0-20191005012637-293c3298d6c0 h1:6DtWz8hNS4qbq0OCRPhdBMG9E2qKTSDKlwnP3dmZvuA=
+github.com/xo/dburl v0.0.0-20191005012637-293c3298d6c0/go.mod h1:A47W3pdWONaZmXuLZgfKLAVgUY0qvfTRM5vVDKS40S4=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/pkg/etc/config.go
+++ b/pkg/etc/config.go
@@ -3,14 +3,16 @@ package etc
 import (
 	"crypto/x509"
 	"fmt"
-	"github.com/caarlos0/env/v6"
-	"github.com/goharbor/harbor-scanner-clair/pkg/harbor"
-	"github.com/sirupsen/logrus"
-	log "github.com/sirupsen/logrus"
 	"io/ioutil"
 	"os"
 	"strings"
 	"time"
+
+	"github.com/caarlos0/env/v6"
+	"github.com/goharbor/harbor-scanner-clair/pkg/harbor"
+	"github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
+	"github.com/xo/dburl"
 )
 
 type Config struct {
@@ -41,7 +43,8 @@ type TLSConfig struct {
 }
 
 type ClairConfig struct {
-	URL string `env:"SCANNER_CLAIR_URL" envDefault:"http://harbor-harbor-clair:6060"`
+	URL         string `env:"SCANNER_CLAIR_URL" envDefault:"http://harbor-harbor-clair:6060"`
+	DatabaseURL string `env:"SCANNER_CLAIR_DATABASE_URL"`
 }
 
 type Store struct {
@@ -88,6 +91,13 @@ func GetConfig() (cfg Config, err error) {
 			return cfg, fmt.Errorf("failed to append %q to root CAs pool: %v", certFile, err)
 		}
 		log.WithField("cert", certFile).Debug("Client CA appended to root CAs pool")
+	}
+
+	if cfg.Clair.DatabaseURL != "" {
+		_, err = dburl.Parse(cfg.Clair.DatabaseURL)
+		if err != nil {
+			return cfg, fmt.Errorf("invalid clair database url %s", cfg.Clair.DatabaseURL)
+		}
 	}
 
 	return

--- a/pkg/mock/clair_client.go
+++ b/pkg/mock/clair_client.go
@@ -1,6 +1,8 @@
 package mock
 
 import (
+	"time"
+
 	"github.com/goharbor/harbor-scanner-clair/pkg/clair"
 	"github.com/stretchr/testify/mock"
 )
@@ -21,4 +23,9 @@ func (cc *ClairClient) ScanLayer(l clair.Layer) error {
 func (cc *ClairClient) GetLayer(layerName string) (*clair.LayerEnvelope, error) {
 	args := cc.Called(layerName)
 	return args.Get(0).(*clair.LayerEnvelope), args.Error(1)
+}
+
+func (cc *ClairClient) GetVulnerabilityDatabaseUpdatedAt() (*time.Time, error) {
+	args := cc.Called()
+	return args.Get(0).(*time.Time), args.Error(1)
 }


### PR DESCRIPTION
returns `harbor.scanner-adapter/vulnerability-database-updated-at` in metadata when config clair database url for the scanner

Signed-off-by: He Weiwei <hweiwei@vmware.com>