### PR TITLE
ci(golang): bump up golang to version 1.14.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- '1.13'
+- '1.14.7'
 git:
   depth: 1
 services:


### PR DESCRIPTION
See https://github.com/goharbor/harbor/pull/12809 for more info

Signed-off-by: He Weiwei <hweiwei@vmware.com>