### PR TITLE
Adding support for proxy when preparing registry layers

### DIFF
--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -47,6 +47,7 @@ func (cf *clientFactory) Get() Client {
 					RootCAs:            cf.tlsConfig.RootCAs,
 					InsecureSkipVerify: cf.tlsConfig.InsecureSkipVerify,
 				},
+                                Proxy: http.ProxyFromEnvironment,
 			}},
 		}
 	})


### PR DESCRIPTION
Container will respect environment variables when connecting to a registry to prepare layers:
HTTP_PROXY
HTTPS_PROXY
NO_PROXY
This is based on https://github.com/quay/clair/pull/530